### PR TITLE
Escape plugin filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function isolate (app, opts) {
         const dir = dirname(opts.path)
         const name = join(dir, `.esm-wrapper-${process.pid}-${counter++}.js`)
         await writeFile(name, `
-          const plugin = import('./${basename(opts.path)}')
+          const plugin = import(${JSON.stringify(`./${basename(opts.path)}`)})
           module.exports = plugin
         `)
         plugin = _require(name)

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -227,3 +227,41 @@ test('different isolates with ESM', async ({ same, teardown }) => {
     same(data, { check: false })
   }
 })
+
+test('can load CommonJS plugin with filename requiring escape', async ({ same, teardown }) => {
+  const app = Fastify()
+  teardown(app.close.bind(app))
+
+  app.register(isolate, {
+    path: path.join(__dirname, '/plugin \'"`.js')
+  })
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/'
+    })
+    const data = res.json()
+
+    same(data, { check: true })
+  }
+})
+
+test('can load ESM plugin with filename requiring escape', async ({ same, teardown }) => {
+  const app = Fastify()
+  teardown(app.close.bind(app))
+
+  app.register(isolate, {
+    path: path.join(__dirname, '/plugin \'"`.mjs')
+  })
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/'
+    })
+    const data = res.json()
+
+    same(data, { check: true })
+  }
+})

--- a/test/plugin '"`.js
+++ b/test/plugin '"`.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (app) {
+  app.get('/', async () => {
+    return { check: true }
+  })
+}

--- a/test/plugin '"`.mjs
+++ b/test/plugin '"`.mjs
@@ -1,0 +1,5 @@
+export default async function (app) {
+  app.get('/', async () => {
+    return { check: true }
+  })
+}


### PR DESCRIPTION
Small change to escape plugin filenames when loading ESM.

e.g. previously if plugin file path was `/path/to/matteo's plugin.mjs` this would generate a syntax error.