### PR TITLE
Allow ESM plugin with `.js` ext

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ async function isolate (app, opts) {
     } catch (err) {
       if (err.code === 'ERR_REQUIRE_ESM') {
         const dir = dirname(opts.path)
-        const name = join(dir, `.esm-wrapper-${process.pid}-${counter++}.js`)
+        const name = join(dir, `.esm-wrapper-${process.pid}-${counter++}.cjs`)
         await writeFile(name, `
           const plugin = import('./${basename(opts.path)}')
           module.exports = plugin


### PR DESCRIPTION
If an ESM plugin has a `.js` file extension in a directory with package.json including `"type": "module"`, `isolate` throws an `ERR_REQUIRE_ESM` error.

Reason is that `isolate` creates a temp file with a `.js` file extension which it then `require()`s. It expects that file to be loaded as CJS, but `"type": "module"` causes Node to treat it as ESM too.

This is solved by giving the temp file a `.cjs` extension.