### PR TITLE
Simplify ESM plugin loading

### DIFF
--- a/esm-wrapper.js
+++ b/esm-wrapper.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = path => import(path)

--- a/index.js
+++ b/index.js
@@ -2,9 +2,10 @@
 
 const importFresh = require('import-fresh')
 const { join } = require('path')
+const { pathToFileURL } = require('url')
 let SynchronousWorker
 
-const esmWrapperPath = join(__dirname, 'virtual-esm-wrapper.js')
+const esmWrapperPath = join(__dirname, 'esm-wrapper.js')
 
 try {
   SynchronousWorker = require('@matteo.collina/worker')
@@ -36,13 +37,8 @@ async function isolate (app, opts) {
       plugin = _require(opts.path)
     } catch (err) {
       if (err.code === 'ERR_REQUIRE_ESM') {
-        const Module = _require('module')
-        const module = new Module(esmWrapperPath)
-        module._compile(
-          `module.exports = import('file://' + ${JSON.stringify(opts.path)})`,
-          esmWrapperPath
-        )
-        plugin = module.exports
+        const _import = _require(esmWrapperPath)
+        plugin = _import(pathToFileURL(opts.path))
       } else {
         throw err
       }


### PR DESCRIPTION
Sorry I didn't see this before, but there's a much simpler way to load ESM than #22.

Each context has its own module cache, so the `esm-wrapper.js` file is loaded anew each time. The fact that the filename is static doesn't matter.