### PR TITLE
Propagate error code

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ async function sandbox (app, opts) {
         const newError = new Error(err.message)
         newError.cause = err
         newError.statusCode = err.statusCode || 500
+        newError.code = err.code || 'FST_SANDBOX_ERROR'
         err = newError
       }
       throw err

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -153,6 +153,25 @@ test('error is the same', async ({ equal, teardown }) => {
   equal(res.statusCode, 500)
   const data = res.json()
   equal(data.message, 'kaboom')
+  equal(data.code, 'FST_SANDBOX_ERROR')
+})
+
+test('error code is propagated', async ({ equal, teardown }) => {
+  const app = Fastify()
+  teardown(app.close.bind(app))
+
+  app.register(isolate, {
+    path: path.join(__dirname, '/plugin.js')
+  })
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/errorcode'
+  })
+  equal(res.statusCode, 500)
+  const data = res.json()
+  equal(data.message, 'kaboom')
+  equal(data.code, 'MY_ERROR_CODE')
 })
 
 test('stopTimeout', async ({ equal, teardown }) => {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -27,6 +27,12 @@ module.exports = async function (app, opts) {
     throw new TypeError('kaboom')
   })
 
+  app.get('/errorcode', () => {
+    const err = new Error('kaboom')
+    err.code = 'MY_ERROR_CODE'
+    throw err
+  })
+
   app.register(async function (app) {
     app.register(require('@fastify/cookie'), {
       secret: 'secret'


### PR DESCRIPTION
This to propagate also the `code` with errors (not only `message` and `statusCode`) to be compatible with errors created with https://github.com/fastify/fastify-error 